### PR TITLE
Adds MANIFEST.in file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include *.txt *.md
+prune examples/sample?/build


### PR DESCRIPTION
Without this file the requirements.txt is missing from the source (sdist) tarball, which results an an error message during installation.

Fixes #6