### PR TITLE
Parallel requests via ThreadPoolExecutor

### DIFF
--- a/src/teampulls
+++ b/src/teampulls
@@ -15,12 +15,15 @@ import os
 import sys
 import toml
 import requests
+from functools import partial
 from os.path import expanduser
 from datetime import datetime
 from datetime import timedelta
 from datetime import timezone
 from dateutil import parser
 from docopt import docopt
+from concurrent.futures import ThreadPoolExecutor as PoolExecutor
+
 
 __docopt__ = """Usage: teampulls [-hu USER]
 
@@ -183,7 +186,7 @@ def print_prs_detail(data):
         data["data"]["user"]["pullRequests"]["nodes"], repos
     )
     if len(pull_requests) == 0:
-        print("No pull requests!")
+        print("No pull requests!\n")
     for i, pr in enumerate(pull_requests):
         title = pr["title"]
         repo = pr["repository"]["nameWithOwner"]
@@ -223,6 +226,7 @@ if __name__ == "__main__":
         # Using users from the config.
         usernames = config_usernames
 
-    for username in usernames:
-        data = get_prs_for_user(username, api_token)
-        print_prs_detail(data)
+    get_prs_for_user_with_api_token = partial(get_prs_for_user, api_token=api_token)
+    with PoolExecutor(max_workers=8) as executor:
+        for data in executor.map(get_prs_for_user_with_api_token, usernames):
+            print_prs_detail(data)


### PR DESCRIPTION
Requrests are now performed in parallel in threads with a `ThreadPoolExecutor`. `max_workers` is currently hard-coded to 8.