### PR TITLE
Better error message for malformed toml file

### DIFF
--- a/teampulls/teampulls.py
+++ b/teampulls/teampulls.py
@@ -126,7 +126,7 @@ def get_settings():
         if os.path.isfile(path) and not os.path.isdir(path) and not os.path.islink(path):
             try:
                 settings = toml.load(path)
-            except:
+            except(toml.decoder.TomlDecodeError):
                 print(
                     "TOML file at \"{}\" seems to be malformed".format(path),
                     file=sys.stderr,

--- a/teampulls/teampulls.py
+++ b/teampulls/teampulls.py
@@ -124,7 +124,14 @@ def get_settings():
     for path in paths:
         path = expanduser(path)
         if os.path.isfile(path) and not os.path.isdir(path) and not os.path.islink(path):
-            settings = toml.load(path)
+            try:
+                settings = toml.load(path)
+            except:
+                print(
+                    "TOML file at \"{}\" seems to be malformed".format(path),
+                    file=sys.stderr,
+                )
+                sys.exit(3)
             break
     if not settings:
         print(

--- a/teampulls/teampulls.py
+++ b/teampulls/teampulls.py
@@ -126,7 +126,7 @@ def get_settings():
         if os.path.isfile(path) and not os.path.isdir(path) and not os.path.islink(path):
             try:
                 settings = toml.load(path)
-            except(toml.decoder.TomlDecodeError):
+            except toml.decoder.TomlDecodeError:
                 print(
                     "TOML file at \"{}\" seems to be malformed".format(path),
                     file=sys.stderr,


### PR DESCRIPTION
Now exists without a stack trace and with a better error message if the toml file cannot be loaded.